### PR TITLE
Add OpenAI 2020 program

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Google X AI Residency [[Link](https://x.company/careers-at-x/4225880002/)]
 - Google AI Resident (Health), 2020 Start - London, UK  [[Link](https://careers.google.com/jobs/results/136709006283416262-google-ai-resident-health-2020-start-fixed-term-employee/?company=Google&company=Google%20Fiber&company=YouTube&employment_type=FULL_TIME&hl=en_US&jlo=en_US&q=Residency%20Program%20Healthcare&sort_by=relevance)]
 - Google AI Resident (Health), 2020 - Start Palo Alto, CA, USA [[Link](https://careers.google.com/jobs/results/95901233513931462-google-ai-resident-health-2020-start-fixed-term-employee/?company=Google&company=Google%20Fiber&company=YouTube&employment_type=FULL_TIME&hl=en_US&jlo=en_US&q=Residency%20Program%20Healthcare&sort_by=relevance)]
+- OpenAI 2020 Winter Scholars [[Link](https://jobs.lever.co/openai/d30e1f04-b548-4503-ba8b-9853cb49bdc7)]. Application Deadline: Nov 15, 2019.
 
 ## 2019
 


### PR DESCRIPTION
Added OpenAI's 2020 Scholars program.

**Timeframe**
- 9/23/2019 Open applications 
- 11/15/2019 Close applications
- 12/13/2019 Notify all accepted applicants
- 2/3/2020 Welcome dinner - cohort start (onsite in SF)
- 5/29/2020 Final project due - cohort end
- 6/5/2020 Demo day (onsite in SF)